### PR TITLE
prevent cache stampede & simultaneous addFunc calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ first in, first out, with a limit on the number of key-value pairs
 
 ### AddFunc
 
-AddFunc is specified for adding new key-value pairs. The cache is not blocked if addFunc takes a longer time to complete. However, there is currently no functionality that prevents simultaneous calls of AddFunc with the same key.
+AddFunc is specified for adding new key-value pairs. The cache is not blocked if addFunc takes a longer time to complete.
+If GetOrAdd is called multiple times with the same key while another addFunc is still busy, all calls will wait for the first addFunc to return and use that result.
 
 ## TFIFO
 
 * A wrapper around FIFO for time-awareness
-* All key-value pairs share a maximum age, **not** per pair
+* All key-value pairs share a maximum age, **not** specified per pair
 * Performance/Memory Note: Does **not** clean itself passively but checks age on access
 
 ## Example
@@ -74,5 +75,4 @@ func doStuff() {
 
 ## TODO
 
-* add an LRU and TLRU cache
-* make resistant to cache stampede
+* add an LRU (and TLRU) cache

--- a/fifo_test.go
+++ b/fifo_test.go
@@ -38,6 +38,16 @@ func TestFIFO(t *testing.T) {
 		assert.Equal(t, 0, v)
 	})
 
+	t.Run(`add and get`, func(t *testing.T) {
+		c := newFIFO()
+
+		c.Add(1, 1)
+
+		v, ok := c.Get(1)
+		assert.True(t, ok)
+		assert.Equal(t, 1, v)
+	})
+
 	t.Run(`get existing`, func(t *testing.T) {
 		c := newFIFO()
 

--- a/keymanager.go
+++ b/keymanager.go
@@ -1,0 +1,48 @@
+package cache
+
+import (
+	"sync"
+)
+
+type result[V any] struct {
+	Value V
+	Err   error
+}
+
+type addManager[K comparable, V any] struct {
+	sync.RWMutex
+
+	busyKeys map[K][]chan result[V]
+}
+
+func (km *addManager[K, V]) waitOrAdd(key K, addFunc AddFunc[V]) <-chan result[V] {
+	km.Lock()
+	defer km.Unlock()
+
+	ch := make(chan result[V])
+
+	channels, ok := km.busyKeys[key]
+	if ok {
+		// wait for existing addFunc
+		km.busyKeys[key] = append(channels, ch)
+		return ch
+	}
+
+	// start a new addFunc
+	km.busyKeys[key] = []chan result[V]{ch}
+	go func() {
+		v, err := addFunc()
+		result := result[V]{v, err}
+
+		km.Lock()
+		defer km.Unlock()
+		for _, ch := range km.busyKeys[key] {
+			ch <- result
+			close(ch)
+		}
+
+		delete(km.busyKeys, key)
+	}()
+
+	return ch
+}

--- a/tfifo_test.go
+++ b/tfifo_test.go
@@ -29,6 +29,16 @@ func TestTFIFO(t *testing.T) {
 		assert.Equal(t, 0, v)
 	})
 
+	t.Run(`add and get`, func(t *testing.T) {
+		c := newTFIFO()
+
+		c.Add(1, 1)
+
+		v, ok := c.Get(1)
+		assert.True(t, ok)
+		assert.Equal(t, 1, v)
+	})
+
 	t.Run(`get existing`, func(t *testing.T) {
 		c := newTFIFO()
 


### PR DESCRIPTION
~~It may be necessary to make the AddFunc a global object on the cache again for this~~